### PR TITLE
Safer type handling of scheduled and timespan fields

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -56,5 +56,14 @@ function xmldb_local_purgeoldassignments_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2025031300, 'local', 'purgeoldassignments');
     }
 
+    if ($oldversion < 2025051300) {
+
+        // Delete broken table rows.
+        $DB->delete_records('local_purgeoldassignments', ['timespan' => '0']);
+
+        // Purgeoldassignments savepoint reached.
+        upgrade_plugin_savepoint(true, 2025051300, 'local', 'purgeoldassignments');
+    }
+
     return true;
 }

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component    = 'local_purgeoldassignments';
-$plugin->release      = 2025031300;
-$plugin->version      = 2025031300;
+$plugin->release      = 2025051300;
+$plugin->version      = 2025051300;
 $plugin->requires     = 2017111300;
 $plugin->supported    = [34, 405];
 $plugin->maturity     = MATURITY_STABLE;


### PR DESCRIPTION
The recent scheduling patch added some unsafe type handling.  I'm interested in fixing this for another patch, but it is causing problems of its own, so probably needs to be fixed anyway.

**Testing**

1. Create a course with an assignment, and make a file submission.
2. In the assignment, click the Purge old assignments tab.
3. Tick Enable scheduled purge, but don't choose an age.
4. Click Save changes.
5. Tick Enable scheduled purge, but don't choose an age.
6. Click Save changes.
7. Verify no error is given (fails before the patch).
8. Tick Enable scheduled purge, and choose 1 year.
9. Click Save changes.
10. Verify Enable scheduled purge is ticked, and 1 year is selected.
11. Choose 2 years.
12. Click Save changes.
13. Verify Enable scheduled purge is ticked, and 2 years is selected.
14. Clear the years drop down.
15. Click Save changes.
16. Verify Enable scheduled purge is ticked, and 2 years remains selected.
17. Untick Enable scheduled purge.
18. Click Save changes.
19. Verify Enable scheduled purge is unticked.
20. Click Save changes.
21. Verify Enable scheduled purge remains unticked.