### PR TITLE
Purge assignments of any age

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -56,5 +56,14 @@ function xmldb_local_purgeoldassignments_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2025031300, 'local', 'purgeoldassignments');
     }
 
+    if ($oldversion < 2025051300) {
+
+        // Delete broken table rows.
+        $DB->delete_records('local_purgeoldassignments', ['timespan' => '0']);
+
+        // Purgeoldassignments savepoint reached.
+        upgrade_plugin_savepoint(true, 2025051300, 'local', 'purgeoldassignments');
+    }
+
     return true;
 }

--- a/lib.php
+++ b/lib.php
@@ -63,7 +63,7 @@ function local_purgeoldassignments_extend_settings_navigation(navigation_node $n
 function local_purgeoldassignments_purge(int $contextid, $component, int $purge) {
     global $DB;
 
-    if (empty($purge) || empty($component) || empty($contextid)) {
+    if (empty($component) || empty($contextid)) {
         // Safety check.
         return;
     }
@@ -71,7 +71,7 @@ function local_purgeoldassignments_purge(int $contextid, $component, int $purge)
         // Not an allowed component.
         return;
     }
-    if ($purge < 1) {
+    if ($purge < 0) {
         return;
     }
     // Check to make sure contextid is valid - if not ignore and return.

--- a/purge.php
+++ b/purge.php
@@ -192,6 +192,7 @@ if (optional_param('savescheduling', false, PARAM_BOOL) && confirm_sesskey()) {
 
             $select = html_writer::label('0', 'menu'. $component . 'timespan', false, ['class' => 'accesshide']);
             $choices = [
+                0 => '0 years',
                 1 => '1 year',
                 2 => '2 years',
                 3 => '3 years'

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component    = 'local_purgeoldassignments';
-$plugin->release      = 2025031300;
-$plugin->version      = 2025031300;
+$plugin->release      = 2025051300;
+$plugin->version      = 2025051300;
 $plugin->requires     = 2017111300;
 $plugin->supported    = [34, 405];
 $plugin->maturity     = MATURITY_STABLE;


### PR DESCRIPTION
Adds an option to purge assignment files of any age.
This incorporates #5.

**Testing**

1. Create a course with an assignment, and make a file submission.
2. In the assignment, click the Purge old assignments tab.
3. Tick Enable scheduled purge, and choose 0 years.
4. Click Save changes.
5. Navigate to Site admin > Server > Tasks > Scheduled tasks > Purge old assignments > Edit
6. Set the time to a minute or two in the future.
7. Click Save changes.
8. Wait for the minute or two to elapse.
9. If cron isn't set up, navigate to /admin/cron.php
10. Reload Site admin > Server > Tasks > Scheduled tasks.
11. Wait until the Purge old assignments Last run time indicated it has recently run.
12. Click Purge old assignments > Edit.
13. Tick Reset task schedule to defaults.
14. Click Save changes.
15. Navigate back to the Assignment > Submissions.
16. Verify there is now no File submission.