### PR TITLE
Remove purged assignments from task list

### DIFF
--- a/classes/task/purge_old_assignments.php
+++ b/classes/task/purge_old_assignments.php
@@ -43,9 +43,13 @@ class purge_old_assignments extends \core\task\scheduled_task {
         $filestopurge = $DB->get_records('local_purgeoldassignments');
 
         foreach ($filestopurge as $file) {
-            $context = \context_module::instance($file->cmid);
+            $context = \context_module::instance($file->cmid, IGNORE_MISSING);
 
-            local_purgeoldassignments_purge($context->id, $file->component, $file->timespan);
+            if (!empty($context)) {
+                local_purgeoldassignments_purge($context->id, $file->component, $file->timespan);
+            } else {
+                $DB->delete_records_list('local_purgeoldassignments', 'id', [$file->id]);
+            }
         }
     }
 }


### PR DESCRIPTION
Assignments scheduled for purging are not removed from the task list once done.

**Testing:**

1. Install Ad-hoc database queries plugin (report_customsql).
2. Enable scheduled purge for an assignment.
3. Navigate to Site admin > Server > Tasks > Scheduled tasks.
4. Edit Purge old assignments task.
5. Set all values to "*".
6. Wait for cron to run, or trigger manually.
7. Navigate to Site admin > Reports > Ad-hoc database queries.
8. Add query as follows:
`SELECT * FROM {local_purgeoldassignments}`
10. Verify no data is returned.  (Fails before the patch.)
11. Navigate to Site admin > Server > Tasks > Scheduled tasks.
12. Edit Purge old assignments task.
13. Reset task schedule to defaults.
